### PR TITLE
update peer dependency semver version

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   },
   "peerDependencies": {
     "grunt": "~0.4.2",
-    "flexpmd": "1.x"
+    "flexpmd": "^1.3.0-2"
   },
   "dependencies": {
     "xmldom": "~0.1.19",


### PR DESCRIPTION
trying to `npm install grunt-flexpmd` would result in an error that `peerDependency flexpmd@1.x was not installed` even though I had it on my system.
